### PR TITLE
use more flexible spectrum reader from lightcurve-fitting

### DIFF
--- a/custom_code/processors/spectroscopy_processor.py
+++ b/custom_code/processors/spectroscopy_processor.py
@@ -1,0 +1,33 @@
+from specutils import Spectrum1D
+from tom_dataproducts.processors.spectroscopy_processor import SpectroscopyProcessor as OldSpectroscopyProcessor
+from tom_dataproducts.exceptions import InvalidFileFormatException
+from lightcurve_fitting.speccal import readspec
+
+
+class SpectroscopyProcessor(OldSpectroscopyProcessor):
+
+    def _process_spectrum_from_plaintext(self, data_product):
+        """
+        Processes the data from a spectrum from a plaintext file into a Spectrum1D object, which can then be serialized
+        and stored as a ReducedDatum for further processing or display. Text files are read using the lightcurve-fitting
+        package: https://griffin-h.github.io/lightcurve_fitting/api.html#lightcurve_fitting.speccal.readspec.
+
+        Parameters
+        ----------
+        :param data_product: Spectroscopic DataProduct which will be processed into a Spectrum1D
+        :type data_product: tom_dataproducts.models.DataProduct
+
+        :returns: Spectrum1D object containing the data from the DataProduct
+        :rtype: specutils.Spectrum1D
+
+        :returns: Datetime of observation, if it is in the comments and the file is from a supported facility, current
+            datetime otherwise
+        :rtype: datetime.datetime
+        """
+
+        wavelength, flux, date_obs, telescope, instrument = readspec(data_product.data.path)
+        if len(flux) < 1:
+            raise InvalidFileFormatException('Empty table or invalid file type')
+        spectrum = Spectrum1D(flux=flux * self.DEFAULT_FLUX_CONSTANT,
+                              spectral_axis=wavelength * self.DEFAULT_WAVELENGTH_UNITS)
+        return spectrum, date_obs.to_datetime()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 tomtoolkit
 psycopg2-binary
 kne_cand_vetting @ git+https://github.com/SAGUARO-MMA/kne-cand-vetting
+lightcurve-fitting

--- a/saguaro_tom/settings.py
+++ b/saguaro_tom/settings.py
@@ -236,7 +236,7 @@ DATA_PRODUCT_TYPES = {
 
 DATA_PROCESSORS = {
     'photometry': 'tom_dataproducts.processors.photometry_processor.PhotometryProcessor',
-    'spectroscopy': 'tom_dataproducts.processors.spectroscopy_processor.SpectroscopyProcessor',
+    'spectroscopy': 'custom_code.processors.spectroscopy_processor.SpectroscopyProcessor',
 }
 
 TOM_FACILITY_CLASSES = [


### PR DESCRIPTION
The default spectroscopy processor in the TOM toolkit is very inflexible and doesn't understand ASCII formats that most people use. This instead uses my custom function from the `lightcurve-fitting` package. It isn't perfect, but it's better, having been tested on a huge number of spectra in the past. To test, just upload some ASCII spectra.