### PR TITLE
add pink to target detail page

### DIFF
--- a/static/tom_common/css/pink.css
+++ b/static/tom_common/css/pink.css
@@ -1,0 +1,8 @@
+h3, h4 {
+    color: #FF69B4;
+}
+
+a.btn-warning {
+    background-color: #FFB6C1;
+    border-color: #FF69B4;
+}

--- a/templates/tom_targets/target_detail.html
+++ b/templates/tom_targets/target_detail.html
@@ -2,6 +2,7 @@
 {% load comments bootstrap4 tom_common_extras targets_extras observation_extras dataproduct_extras target_list_extras static cache %}
 {% block title %}Target {{ object.name }}{% endblock %}
 {% block additional_css %}
+<link rel="stylesheet" href="{% static 'tom_common/css/pink.css' %}">
 <link rel="stylesheet" href="{% static 'tom_common/css/main.css' %}">
 <link rel="stylesheet" href="{% static 'tom_targets/css/main.css' %}">
 {% endblock %}


### PR DESCRIPTION
This adds the pink styling from PR #9 back to the target detail page using CSS.