### PR TITLE
create a candidate vetting button

### DIFF
--- a/custom_code/urls.py
+++ b/custom_code/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 
 from tom_targets.views import TargetGroupingView, TargetGroupingDeleteView
-from .views import TargetGroupingCreateView, CandidateListView, TargetReportView, TargetClassifyView
+from .views import TargetGroupingCreateView, CandidateListView, TargetReportView, TargetClassifyView, TargetVettingView
 
 from tom_common.api_router import SharedAPIRootRouter
 
@@ -16,4 +16,5 @@ urlpatterns = [
     path('candidates/', CandidateListView.as_view(), name='candidates'),
     path('targets/<int:pk>/report/', TargetReportView.as_view(), name='report'),
     path('targets/<int:pk>/classify/', TargetClassifyView.as_view(), name='classify'),
+    path('targets/<int:pk>/vet/', TargetVettingView.as_view(), name='vet'),
 ]

--- a/templates/tom_targets/partials/target_buttons.html
+++ b/templates/tom_targets/partials/target_buttons.html
@@ -4,4 +4,5 @@
     <a href="{% url 'custom_code:report' pk=target.id %}" title="Report target to TNS" class="btn btn-secondary">Report</a>
 {% endif %}
 <a href="{% url 'tom_targets:update' pk=target.id %}" title="Update target details" class="btn  btn-primary">Update</a>
+<a href="{% url 'custom_code:vet' pk=target.id %}" title="Run kilonova candidate vetting" class="btn  btn-info">Vet</a>
 <a href="{% url 'tom_targets:delete' pk=target.id %}" title="Delete target" class="btn  btn-warning">Delete</a>


### PR DESCRIPTION
This resolves Issue #4, which asks for a button to run or rerun @jrastinejad's kilonova candidate vetting code. In practice, the candidate vetting code should have run at least once on all the targets when they were created, but this allows us to update the results based on new data. It checks whether the output `TargetExtra`s have been created, and updates their values if so.