### PR TITLE
Add candidates tab to target detail page

### DIFF
--- a/custom_code/templatetags/target_list_extras.py
+++ b/custom_code/templatetags/target_list_extras.py
@@ -1,5 +1,5 @@
 from django import template
-from ..models import TargetListExtra
+from ..models import Candidate, TargetListExtra
 from tom_targets.models import TargetExtra
 import json
 
@@ -28,3 +28,12 @@ def galaxy_table(target):
     else:
         galaxies = None
     return {'galaxies': galaxies}
+
+
+@register.inclusion_tag('tom_targets/partials/candidates_table.html')
+def candidates_table(target):
+    """
+    Displays a table of all the candidates (detections) associated with a given target, including thumbnails
+    """
+    candidates = Candidate.objects.filter(target=target).all()
+    return {'candidates': candidates}

--- a/templates/tom_targets/candidate_list.html
+++ b/templates/tom_targets/candidate_list.html
@@ -37,13 +37,13 @@
           <td>{{ candidate.fwhm|floatformat:"1" }}</td>
           <td>{{ candidate.snr|floatformat:"1" }}</td>
           <td>{{ candidate.mlscore|floatformat:"2" }}</td>
-          <td><img src="{{ candidate|thumbnail_url }}_img.png" height="80"></td>
-          <td><img src="{{ candidate|thumbnail_url }}_ref.png" height="80"></td>
-          <td><img src="{{ candidate|thumbnail_url }}_diff.png" height="80"></td>
+          <td><img alt="new image" src="{{ candidate|thumbnail_url }}_img.png" height="80"></td>
+          <td><img alt="reference image" src="{{ candidate|thumbnail_url }}_ref.png" height="80"></td>
+          <td><img alt="difference image" src="{{ candidate|thumbnail_url }}_diff.png" height="80"></td>
         </tr>
         {% empty %}
         <tr>
-          <td colspan="5">
+          <td colspan="10">
             {% if target_count == 0 %}
             No candidates yet.
             {% else %}

--- a/templates/tom_targets/partials/candidates_table.html
+++ b/templates/tom_targets/partials/candidates_table.html
@@ -1,0 +1,32 @@
+{% load tom_common_extras candidate_extras target_list_extras %}
+
+<table class="table table-hover">
+  <thead>
+    <tr>
+      <th>Obs. Date</th>
+      <th>Mag.</th>
+      <th>FWHM</th>
+      <th>S/N</th>
+      <th>ML Score</th>
+      <th>Image</th>
+      <th>Reference</th>
+      <th>Difference</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for candidate in candidates %}
+    <tr>
+      <td>{{ candidate.obsdate|date:"Y-m-d" }}</td>
+      <td>{{ candidate.mag|floatformat:"1" }}</td>
+      <td>{{ candidate.fwhm|floatformat:"1" }}</td>
+      <td>{{ candidate.snr|floatformat:"1" }}</td>
+      <td>{{ candidate.mlscore|floatformat:"2" }}</td>
+      <td><img alt="new image" src="{{ candidate|thumbnail_url }}_img.png" height="80"></td>
+      <td><img alt="reference image" src="{{ candidate|thumbnail_url }}_ref.png" height="80"></td>
+      <td><img alt="difference image" src="{{ candidate|thumbnail_url }}_diff.png" height="80"></td>
+    </tr>
+    {% empty %}
+    <tr><td colspan="8">No candidates yet.</td></tr>
+    {% endfor %}
+  </tbody>
+</table>

--- a/templates/tom_targets/partials/galaxy_table.html
+++ b/templates/tom_targets/partials/galaxy_table.html
@@ -1,4 +1,4 @@
-{% load tom_common_extras targets_extras target_list_extras %}
+{% load tom_common_extras target_list_extras %}
 
 <table class="table table-hover">
   <thead>

--- a/templates/tom_targets/target_detail.html
+++ b/templates/tom_targets/target_detail.html
@@ -44,6 +44,9 @@ $(document).ready(function(){
   <div class="col-md-8">
     <ul class="nav nav-tabs" role="tablist" id="tabs">
       <li class="nav-item">
+        <a class="nav-link" id="candidates-tab" href="#candidates" role="tab" data-toggle="tab">Candidates</a>
+      </li>
+      <li class="nav-item">
         <a class="nav-link" id="host-galaxy-tab" href="#host-galaxy" role="tab" data-toggle="tab">Host Galaxies</a>
       </li>
       <li class="nav-item">
@@ -82,6 +85,10 @@ $(document).ready(function(){
         {% elif target.type == 'NON_SIDEREAL' %}
           <p>Airmass plotting for non-sidereal targets is not currently supported. If you would like to add this functionality, please check out the <a href="https://github.com/TOMToolkit/tom_nonsidereal_airmass" target="_blank">non-sidereal airmass plugin.</a></p>
         {% endif %}
+      </div>
+      <div class="tab-pane" id='candidates'>
+        <h4>Candidates</h4>
+        {% candidates_table object %}
       </div>
       <div class="tab-pane" id='host-galaxy'>
         <h4>Host Galaxies with Lowest Probability of Chance Coincidence</h4>


### PR DESCRIPTION
This adds a new tab to the target detail page showing all the "candidates" (SAGUARO observations) for that target in a table, with image subtraction triplets.