### PR TITLE
Updates to MMT interface

### DIFF
--- a/custom_code/mmt.py
+++ b/custom_code/mmt.py
@@ -128,15 +128,17 @@ class MMTFacility(BaseRoboticObservationFacility):
     }
 
     def data_products(self, observation_id, product_id=None):
-        datalist = mmtapi.Datalist(token=MMT_SETTINGS['api_key'])
-        datalist.get(targetid=observation_id)
+        response = requests.get(f"https://scheduler.mmto.arizona.edu/APIv2/data/list/catalogtarget/{observation_id}/"
+                                f"token/{MMT_SETTINGS['api_key']}/type/reduced")
 
-        # flatten the dictionary structure across all "queues"
+        # flatten the dictionary structure across all data sets
         data_products = []
-        for dp in datalist.data:
-            file_info = dp['datafiles']
-            file_info['id'] = file_info['datafileid']
-            data_products += file_info
+        for datalist in response.json():
+            datafiles = datalist['datafiles']
+            for file_info in datafiles:
+                file_info['url'] = f"https://scheduler.mmto.arizona.edu/APIv2/data/download/datafile/" \
+                                   f"{file_info['id']}/token/{MMT_SETTINGS['api_key']}"
+            data_products += datafiles
 
         return data_products
 

--- a/custom_code/mmt.py
+++ b/custom_code/mmt.py
@@ -26,11 +26,13 @@ class MMTBaseObservationForm(BaseRoboticObservationForm):
     target_of_opportunity = forms.BooleanField(initial=True)
 
     def is_valid(self):
-        super().is_valid()
+        self.full_clean()
         facility = MMTFacility()
         observation_payload = self.observation_payload()
         errors = facility.validate_observation(observation_payload)
-        self.add_error(None, errors)
+        if errors:
+            self.add_error(None, errors)
+        return super().is_valid()
 
 
 class MMTImagingForm(MMTBaseObservationForm):

--- a/custom_code/mmt.py
+++ b/custom_code/mmt.py
@@ -135,16 +135,17 @@ class MMTFacility(BaseRoboticObservationFacility):
     }
 
     def data_products(self, observation_id, product_id=None):
-        response = requests.get(f"https://scheduler.mmto.arizona.edu/APIv2/data/list/catalogtarget/{observation_id}/"
-                                f"token/{MMT_SETTINGS['api_key']}/type/reduced")
+        datalist = mmtapi.Datalist(token=MMT_SETTINGS['api_key'])
+        datalist.get(targetid=observation_id, data_type='reduced')
 
         # flatten the dictionary structure across all data sets
         data_products = []
-        for datalist in response.json():
+        for datalist in datalist.data:
             datafiles = datalist['datafiles']
             for file_info in datafiles:
-                file_info['url'] = f"https://scheduler.mmto.arizona.edu/APIv2/data/download/datafile/" \
-                                   f"{file_info['id']}/token/{MMT_SETTINGS['api_key']}"
+                image = mmtapi.Image(token=MMT_SETTINGS['api_key'])
+                image._build_url({'datafileid': file_info['id'], 'token': MMT_SETTINGS['api_key']})
+                file_info['url'] = image.url
             data_products += datafiles
 
         return data_products

--- a/custom_code/urls.py
+++ b/custom_code/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from tom_targets.views import TargetGroupingView, TargetGroupingDeleteView
 from .views import TargetGroupingCreateView, CandidateListView, TargetReportView, TargetClassifyView
+from .views import ObservationCreateView
 
 from tom_common.api_router import SharedAPIRootRouter
 
@@ -16,4 +17,5 @@ urlpatterns = [
     path('candidates/', CandidateListView.as_view(), name='candidates'),
     path('targets/<int:pk>/report/', TargetReportView.as_view(), name='report'),
     path('targets/<int:pk>/classify/', TargetClassifyView.as_view(), name='classify'),
+    path('observations/<str:facility>/create/', ObservationCreateView.as_view(), name='create'),
 ]

--- a/custom_code/views.py
+++ b/custom_code/views.py
@@ -9,6 +9,7 @@ from django.shortcuts import redirect
 from guardian.mixins import PermissionListMixin
 
 from tom_targets.models import Target, TargetList
+from tom_observations.views import ObservationCreateView as OldObservationCreateView
 from custom_code.models import Candidate
 from custom_code.filters import CandidateFilter
 from .forms import TargetListExtraFormset, TargetReportForm, TargetClassifyForm
@@ -242,3 +243,16 @@ class TargetClassifyView(PermissionListMixin, TemplateResponseMixin, FormMixin, 
 
     def get_success_url(self):
         return reverse_lazy('targets:detail', kwargs=self.kwargs)
+
+
+class ObservationCreateView(OldObservationCreateView):
+    """
+    Modify the built-in ObservationCreateView to populate any "magnitude" field with the latest observed magnitude
+    """
+    def get_initial(self):
+        initial = super().get_initial()
+        target = self.get_target()
+        photometry = target.reduceddatum_set.filter(data_type='photometry')
+        if photometry.exists():
+            initial['magnitude'] = photometry.latest().value['magnitude']
+        return initial


### PR DESCRIPTION
This adds the following features to the MMT interface:
- view and download reduced data
- display observation submission errors as a banner
- upload finder charts
- automatically populate "current magnitude" field in observation request

These changes require some updates to the `mmtapi` package. I have a [PR](https://github.com/swyatt7/mmtapi/pull/1) open on that repository.