### PR TITLE
switch DEFAULT_AUTO_FIELD to BigAutoField

### DIFF
--- a/saguaro_tom/settings.py
+++ b/saguaro_tom/settings.py
@@ -125,7 +125,7 @@ DATABASES = {
     }
 }
 
-DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 # Password validation
 # https://docs.djangoproject.com/en/2.1/ref/settings/#auth-password-validators


### PR DESCRIPTION
I think we already made this change in the database to increase the maximum target ID. However this migration seems to have effects on other TOM Toolkit apps that I don't totally understand. We should investigate and make sure this is okay before merging, but I'm opening a PR so we don't lose track of it.