### PR TITLE
Regrouping the view with the queryset order by 'target_id'

### DIFF
--- a/custom_code/decam_views.py
+++ b/custom_code/decam_views.py
@@ -161,9 +161,9 @@ class DecamCandidateListView(ListView):
         # NULLs will be at the end
         from django.db.models import F
         return queryset.order_by(
- 	     F('cnnscore').desc(nulls_last=True),
+ 	    'target_id',
+	     F('cnnscore').desc(nulls_last=True),
 	     F('snr_fphot').desc(nulls_last=True),
-            'target_id',       # Group by target
             'filter_name'      # g, i, r, z within each target
         )
     


### PR DESCRIPTION
For non duplication and regrouping the view page by target (so that multiple filters are not duplicated as rows but instead are grouped per target).
