### PR TITLE
Tell Slack not to unfurl links

### DIFF
--- a/slack_notifier/slack_notifier.py
+++ b/slack_notifier/slack_notifier.py
@@ -45,12 +45,16 @@ class SlackNotifier(WebClient):
                         channel = channel,
                         text = msg,
                         thread_ts = thread_id,
-                        reply_broadcast = True
+                        reply_broadcast = True,
+                        unfurl_links = False,
+                        unfurl_media = False,
                     )
                 else:
                     self.chat_postMessage(
                         channel = channel,
                         text = msg,
+                        unfurl_links = False,
+                        unfurl_media = False,
                     )
             except Exception as exc:
                 logger.warning(f"Sending the slack message crashed with {exc}")

--- a/slack_notifier/util.py
+++ b/slack_notifier/util.py
@@ -30,7 +30,7 @@ def send_slack_gw(body, format_kwargs, is_test_alert=False, is_significant=True,
         logger.info(f'Sending GW alert: {body_slack}')
         if channel is None:
             break  # just print out test alerts for debugging
-        slack_client.chat_postMessage(channel=channel, text=body_slack)
+        slack_client.chat_postMessage(channel=channel, text=body_slack, unfurl_links=False, unfurl_media=False)
         if not all_workspaces:
             break
 


### PR DESCRIPTION
Closes #176 by adding `unfurl_links=False, unfurl_media=False` to all our Slack requests.