### PR TITLE
Modify slack alerts from ANTARES stream

### DIFF
--- a/custom_code/alertstream_handlers.py
+++ b/custom_code/alertstream_handlers.py
@@ -332,7 +332,7 @@ def serialize_antares_alert(locus):
                 {
                     'alert_id': alert.alert_id,
                     'mjd': alert.mjd,
-                    'properties': {key: val for key, val in alert.properties.items() if not key.startswith('lsst_dia')},
+                    'properties': {key: val for key, val in alert.properties.items() if key.startswith('ant')},
                 }
                 for alert in locus.alerts
             ],

--- a/custom_code/alertstream_handlers.py
+++ b/custom_code/alertstream_handlers.py
@@ -341,20 +341,21 @@ def serialize_antares_alert(locus):
 
 def handle_antares_stream_async(locus):
     # temporarily skip old alerts TODO: decide if we want this
-    if locus.properties['newest_alert_observation_time'] < np.floor(Time.now().mjd):
-        logger.debug(f'skipping old alert {locus.locus_id}')
-        return
-
+    #if locus.properties['newest_alert_observation_time'] < np.floor(Time.now().mjd):
+    #    logger.debug(f'skipping old alert {locus.locus_id}')
+    #    return
+    #import pdb; pdb.set_trace()
     alert_small = serialize_antares_alert(locus)
     alert_finite = nan2str(alert_small)
     try:
-        handle_antares_stream.enqueue(alert_finite)
+        #handle_antares_stream.enqueue(alert_finite)
+        handle_antares_stream(alert_finite)
         logger.debug(f'sent {locus.locus_id} to queue')
     except Exception as exc:
         dump_alert_and_send_error(alert_finite, exc)
 
 
-@task(queue_name="antares")
+#@task(queue_name="antares")
 def handle_antares_stream(alert, cone_search_radius_arcsec=2.):
     try:
         broker = ANTARESBroker()

--- a/custom_code/alertstream_handlers.py
+++ b/custom_code/alertstream_handlers.py
@@ -344,18 +344,16 @@ def handle_antares_stream_async(locus):
     #if locus.properties['newest_alert_observation_time'] < np.floor(Time.now().mjd):
     #    logger.debug(f'skipping old alert {locus.locus_id}')
     #    return
-    #import pdb; pdb.set_trace()
     alert_small = serialize_antares_alert(locus)
     alert_finite = nan2str(alert_small)
     try:
-        #handle_antares_stream.enqueue(alert_finite)
-        handle_antares_stream(alert_finite)
+        handle_antares_stream.enqueue(alert_finite)
         logger.debug(f'sent {locus.locus_id} to queue')
     except Exception as exc:
         dump_alert_and_send_error(alert_finite, exc)
 
 
-#@task(queue_name="antares")
+@task(queue_name="antares")
 def handle_antares_stream(alert, cone_search_radius_arcsec=2.):
     try:
         broker = ANTARESBroker()

--- a/saguaro_tom/settings.py
+++ b/saguaro_tom/settings.py
@@ -396,7 +396,7 @@ REST_FRAMEWORK = {
 
 ALERT_STREAMS = [
     {
-        'ACTIVE': True,
+        'ACTIVE': False,
         'NAME': 'tom_alertstreams.alertstreams.hopskotch.HopskotchAlertStream',
         'OPTIONS': {
             'URL': 'kafka://kafka.scimma.org/',
@@ -417,11 +417,11 @@ ALERT_STREAMS = [
         'OPTIONS': {
             'API_KEY': ANTARES_API_KEY,
             'API_SECRET': ANTARES_API_SECRET,
-            'GROUP': "noah1", #ANTARES_GROUP_ID,
+            'GROUP': ANTARES_GROUP_ID,
             'TOPIC_HANDLERS': {
-                #'in_shadow_virgo': 'custom_code.alertstream_handlers.handle_antares_stream_async',
+                'in_shadow_virgo': 'custom_code.alertstream_handlers.handle_antares_stream_async',
                 #'in_lsst_ddf': 'custom_code.alertstream_handlers.handle_antares_stream_async',
-                'extragalactic_staging': 'custom_code.alertstream_handlers.handle_antares_stream_async',
+                #'extragalactic_staging': 'custom_code.alertstream_handlers.handle_antares_stream_async',
             }
         },
     }

--- a/saguaro_tom/settings.py
+++ b/saguaro_tom/settings.py
@@ -417,9 +417,11 @@ ALERT_STREAMS = [
         'OPTIONS': {
             'API_KEY': ANTARES_API_KEY,
             'API_SECRET': ANTARES_API_SECRET,
-            'GROUP': ANTARES_GROUP_ID,
+            'GROUP': "noah1", #ANTARES_GROUP_ID,
             'TOPIC_HANDLERS': {
-                'in_shadow_virgo': 'custom_code.alertstream_handlers.handle_antares_stream_async',
+                #'in_shadow_virgo': 'custom_code.alertstream_handlers.handle_antares_stream_async',
+                #'in_lsst_ddf': 'custom_code.alertstream_handlers.handle_antares_stream_async',
+                'extragalactic_staging': 'custom_code.alertstream_handlers.handle_antares_stream_async',
             }
         },
     }

--- a/slack_notifier/slack_filters.py
+++ b/slack_notifier/slack_filters.py
@@ -33,16 +33,17 @@ class AntaresSlackFilter(SlackNotifier):
         peak = target.reduceddatum_set.order_by('value__magnitude').first()
         peak_mag = peak.value['magnitude'] if peak else np.nan
 
+
         if ((has_vs_match or has_agn_match) and telescope_stream == "ZTF") or peak_mag > 21.:
             # don't send this message!
             return
         
         if created:
-            base_str = f"{target.name} created from the Antares alert stream."
+            base_str = f"{target.name} created from the {telescope_stream} alert stream."
         elif not created and len(aliases_added):
-            base_str = f"{target.name} has been updated from the Antares alert stream with the following aliases: {', '.join(aliases_added)}"
+            base_str = f"{target.name} has been updated from the {telescope_stream} alert stream with the following aliases: {', '.join(aliases_added)}"
         else:
-            base_str = f"{target.name} has been updated from the Antares alert stream."
+            base_str = f"{target.name} has been updated from the {telescope_stream} alert stream."
         if np.isfinite(peak_mag):
             base_str += f" ({peak_mag:.1f} mag)"
 

--- a/slack_notifier/slack_filters.py
+++ b/slack_notifier/slack_filters.py
@@ -36,27 +36,36 @@ class AntaresSlackFilter(SlackNotifier):
         peak_mag = peak.value['magnitude'] if peak else np.nan
 
         #Check that the first alert is now
-        first_alert_mjd = Time(target.reduceddatum_set.filter(data_type="photometry", value__magnitude__isnull = False).earliest()).mjd
+        first_alert_mjd = Time(
+            target.reduceddatum_set.filter(
+                data_type="photometry",
+                value__magnitude__isnull = False
+            ).earliest().timestamp
+        ).mjd
 
         # want to ignore non-detections
         # And then also throw out anything with a low SNR before a day
+        latest = target.reduceddatum_set.filter(data_type="photometry", value__magnitude__isnull = False).latest()
         previous_detections = target.reduceddatum_set.filter(
             Q(data_type="photometry") &
             Q(value__magnitude__isnull = False) &
-            Q(timestamp__lt = datetime.now()-timedelta(1)) &
+            Q(timestamp__lt = latest.timestamp-timedelta(1)) &
             Q(value__error__lt = 0.1)
         )
         new_alert = previous_detections.count() == 0
 
         if not new_alert:
-            latest_det_mjd = target.reduceddatum_set.filter(data_type="photometry", value__magnitude__isnull = False).latest()
-            latest_det_mag = target.reduceddatum_set.filter(data_type="photometry", value__magnitude__isnull = False).latest().value['magnitude']
+            latest_det_mag = latest.value['magnitude']
 
-            second_to_last_det_mjd = target.reduceddatum_set.filter(data_type="photometry", timestamp__lt = latest.timestamp).latest()
-            second_to_last_det_mag = target.reduceddatum_set.filter(data_type="photometry", timestamp__lt = latest.timestamp).latest().value['magnitude']
+            second_to_last_det = target.reduceddatum_set.filter(
+                data_type="photometry",
+                timestamp__lt = latest.timestamp,
+                value__magnitude__isnull = False
+            ).latest()
+            second_to_last_det_mag = second_to_last_det.value['magnitude']
 
-            delta_mag = latest_det_mag - second_to_last_det_mag
-            delta_t = latest_det_mjd - second_to_last_det_mjd
+            delta_mag = abs(latest_det_mag - second_to_last_det_mag)
+            delta_t = Time(latest.timestamp).mjd - Time(second_to_last_det.timestamp).mjd
             rise_rate = delta_mag/delta_t #mag/day
 
         if has_vs_match or has_agn_match:
@@ -69,12 +78,12 @@ class AntaresSlackFilter(SlackNotifier):
             base_str = f"First Detection of {target.name} in the {telescope_stream} alert stream."
         #if not new, look for rapidly rising
         elif rise_rate<-0.5: 
-            base_str = f"Rapidly rising object {target.name} in the {telescope_stream} alert stream ({rise_rate:0.2f}<-0.5 mag/day)"
+            base_str = f"Rapidly rising object {target.name} in the {telescope_stream} alert stream at {rise_rate:0.2f} mag/day"
             if len(aliases_added):
                 base_str += f" aliases: {', '.join(aliases_added)}"
         # Even if sparsely spaced, catch things that significantly change
         elif delta_mag < -0.5:
-            base_str = f"Rapidly rising object {target.name} in the {telescope_stream} alert stream ({delta_mag:1.2f}<-0.5 mag since last detection {delta_t:1.2f} days ago)"
+            base_str = f"Rapidly rising object {target.name} in the {telescope_stream} alert stream, changing by {delta_mag:1.2f} mag since last detection {delta_t:1.2f} days ago)"
             if len(aliases_added):
                 base_str += f" aliases: {', '.join(aliases_added)}"
         else:
@@ -82,7 +91,7 @@ class AntaresSlackFilter(SlackNotifier):
             return
 
         if np.isfinite(peak_mag):
-            base_str += f"\n Brightest mag ({peak_mag:.1f} mag)"
+            base_str += f"\nBrightest at {peak_mag:.1f} mag"
 
         # host info
         if target_extra.value != 'None':
@@ -102,7 +111,7 @@ class AntaresSlackFilter(SlackNotifier):
         # photometry info
         # TODO: Put some text in the slack message about the rise rate, etc.
         target.tns_objname = split_name(target.name)['tns_objname']
-        base_str += ' ' + ALERT_LINKS.format(target=target)
+        base_str += ' ' + ALERT_LINKS.format(target=target) 
         return base_str
                 
 class DistanceLimitedSlackFilter(SlackNotifier):

--- a/slack_notifier/slack_filters.py
+++ b/slack_notifier/slack_filters.py
@@ -3,6 +3,7 @@ Custom filters (i.e., subclasses of SlackNotifier)
 """
 import json
 from datetime import datetime
+from astropy.time import Time
 import numpy as np
 
 from .slack_notifier import SlackNotifier
@@ -33,19 +34,48 @@ class AntaresSlackFilter(SlackNotifier):
         peak = target.reduceddatum_set.order_by('value__magnitude').first()
         peak_mag = peak.value['magnitude'] if peak else np.nan
 
+        #Check that the first alert is now
+        first_alert_mjd = Time(target.reduceddatum_set.filter(data_type="photometry", value__magnitude__isnull = False).earliest()).mjd
+        now_mjd = Time(datetime.now()).mjd
 
-        if ((has_vs_match or has_agn_match) and telescope_stream == "ZTF") or peak_mag > 21.:
+        #want to ignore non-detections
+        new_target = len(target.reduceddatum_set.filter(data_type="photometry", value__magnitude__isnull = False))==1
+
+        if not new_alert:
+            latest_det_mjd = test_target.reduceddatum_set.filter(data_type="photometry", value__magnitude__isnull = False).latest()
+            latest_det_mag = test_target.reduceddatum_set.filter(data_type="photometry", value__magnitude__isnull = False).latest().value['magnitude']
+
+            second_to_last_det_mjd = test_target.reduceddatum_set.filter(data_type="photometry", timestamp__lt = latest.timestamp).latest()
+            second_to_last_det_mag = test_target.reduceddatum_set.filter(data_type="photometry", timestamp__lt = latest.timestamp).latest().value['magnitude']
+
+            delta_mag = latest_det_mag - second_to_last_det_mag
+            delta_t = latest_det_mjd - second_to_last_det_mjd
+            rise_rate = delta_mag/delta_t #mag/day
+
+        if (has_vs_match or has_agn_match) or peak_mag > 21.:
             # don't send this message!
             return
         
-        if created:
-            base_str = f"{target.name} created from the {telescope_stream} alert stream."
-        elif not created and len(aliases_added):
-            base_str = f"{target.name} has been updated from the {telescope_stream} alert stream with the following aliases: {', '.join(aliases_added)}"
+        #Report all new objects
+        #We create things with a lot of past detections so created != new_target
+        if new_target:
+            base_str = f"First Detection of {target.name} in the {telescope_stream} alert stream."
+        #if not new, look for rapidly rising
+        elif rise_rate<-0.5: 
+            base_str = f"Rapidly rising object {target.name} in the {telescope_stream} alert stream ({rise_rate:0.2f}<-0.5 mag/day)"
+            if len(aliases_added):
+                base_str += f" aliases: {', '.join(aliases_added)}"
+        # Even if sparsely spaced, catch things that significantly change
+        elif delta_mag < -0.5:
+            base_str = f"Rapidly rising object {target.name} in the {telescope_stream} alert stream ({delta_mag:1.2f}<-0.5 mag since last detection {delta_t:1.2f} days ago)"
+            if len(aliases_added):
+                base_str += f" aliases: {', '.join(aliases_added)}"
         else:
-            base_str = f"{target.name} has been updated from the {telescope_stream} alert stream."
+            # don't send this message!
+            return
+
         if np.isfinite(peak_mag):
-            base_str += f" ({peak_mag:.1f} mag)"
+            base_str += f"\n Brightest mag ({peak_mag:.1f} mag)"
 
         # host info
         if target_extra.value != 'None':
@@ -61,22 +91,6 @@ class AntaresSlackFilter(SlackNotifier):
             base_str += f"\nNo host galaxies are found in SAGUARO for {target.name}\n"
 
         base_str += "\n"
-            
-        # variable star and AGN matches
-        if has_agn_match:
-            base_str += f"\nAGN Match: {agn_match.value}"
-
-        if has_vs_match:
-            base_str += "Variable Star Matches:\n"
-            for vs_match in vs_matches:
-                if vs_match.value == 'None': continue
-                base_str += f"\t* {vs_match.value} offset by "
-                if vs_match.key == "Gaia Match":
-                    vs_offset = target.targetextra_set.filter(key='Gaia VS Offset').first()
-                    base_str += f"{float(vs_offset.value):.3f}\"\n"
-                else:
-                    base_str += f"<2\"\n"
-                    
                 
         # photometry info
         # TODO: Put some text in the slack message about the rise rate, etc.

--- a/slack_notifier/slack_filters.py
+++ b/slack_notifier/slack_filters.py
@@ -2,13 +2,14 @@
 Custom filters (i.e., subclasses of SlackNotifier)
 """
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 from astropy.time import Time
 import numpy as np
 
 from .slack_notifier import SlackNotifier
 from tom_targets.templatetags.targets_extras import deg_to_sexigesimal
 from custom_code.templatetags.target_extras import split_name
+from django.db.models import Q
 from django.conf import settings
 
 ALERT_LINKS = ' '.join([f'<{link}|{service}>' for link, service in settings.TARGET_LINKS])
@@ -36,17 +37,23 @@ class AntaresSlackFilter(SlackNotifier):
 
         #Check that the first alert is now
         first_alert_mjd = Time(target.reduceddatum_set.filter(data_type="photometry", value__magnitude__isnull = False).earliest()).mjd
-        now_mjd = Time(datetime.now()).mjd
 
-        #want to ignore non-detections
-        new_target = len(target.reduceddatum_set.filter(data_type="photometry", value__magnitude__isnull = False))==1
+        # want to ignore non-detections
+        # And then also throw out anything with a low SNR before a day
+        previous_detections = target.reduceddatum_set.filter(
+            Q(data_type="photometry") &
+            Q(value__magnitude__isnull = False) &
+            Q(timestamp__lt = datetime.now()-timedelta(1)) &
+            Q(value__error__lt = 0.1)
+        )
+        new_alert = previous_detections.count() == 0
 
         if not new_alert:
-            latest_det_mjd = test_target.reduceddatum_set.filter(data_type="photometry", value__magnitude__isnull = False).latest()
-            latest_det_mag = test_target.reduceddatum_set.filter(data_type="photometry", value__magnitude__isnull = False).latest().value['magnitude']
+            latest_det_mjd = target.reduceddatum_set.filter(data_type="photometry", value__magnitude__isnull = False).latest()
+            latest_det_mag = target.reduceddatum_set.filter(data_type="photometry", value__magnitude__isnull = False).latest().value['magnitude']
 
-            second_to_last_det_mjd = test_target.reduceddatum_set.filter(data_type="photometry", timestamp__lt = latest.timestamp).latest()
-            second_to_last_det_mag = test_target.reduceddatum_set.filter(data_type="photometry", timestamp__lt = latest.timestamp).latest().value['magnitude']
+            second_to_last_det_mjd = target.reduceddatum_set.filter(data_type="photometry", timestamp__lt = latest.timestamp).latest()
+            second_to_last_det_mag = target.reduceddatum_set.filter(data_type="photometry", timestamp__lt = latest.timestamp).latest().value['magnitude']
 
             delta_mag = latest_det_mag - second_to_last_det_mag
             delta_t = latest_det_mjd - second_to_last_det_mjd
@@ -58,7 +65,7 @@ class AntaresSlackFilter(SlackNotifier):
         
         #Report all new objects
         #We create things with a lot of past detections so created != new_target
-        if new_target:
+        if new_alert:
             base_str = f"First Detection of {target.name} in the {telescope_stream} alert stream."
         #if not new, look for rapidly rising
         elif rise_rate<-0.5: 

--- a/slack_notifier/slack_filters.py
+++ b/slack_notifier/slack_filters.py
@@ -52,7 +52,7 @@ class AntaresSlackFilter(SlackNotifier):
             delta_t = latest_det_mjd - second_to_last_det_mjd
             rise_rate = delta_mag/delta_t #mag/day
 
-        if (has_vs_match or has_agn_match) or peak_mag > 21.:
+        if has_vs_match or has_agn_match:
             # don't send this message!
             return
         


### PR DESCRIPTION
This modifies slack alerts to:
* the survey the latest alert is from
* remove notifications for LSST things that cross-match with AGN or Variable stars
* Only notify us of things that are new (this is the first alert) or rapidly rebrightening 