### PR TITLE
Feature/evcc galaxy association

### DIFF
--- a/custom_code/forms.py
+++ b/custom_code/forms.py
@@ -191,6 +191,120 @@ TNS_GROUP_CHOICES.insert(0, (0, "None"))
 TNS_DATA_SOURCE_GROUP_CHOICES.sort(key=lambda x: x[1])
 TNS_DATA_SOURCE_GROUP_CHOICES.insert(0, (0, "None"))
 
+TNS_REPORTER_GROUPS = {
+    0: [],    # None
+    30: [],   # DLT40
+    38: [],   # Global SN Project
+    52: [     # AZTEC
+        "Brian Hsu (U. Arizona)",
+        "Noah Franz (U. Arizona)",
+        "Jeniveve Pearson (U. Arizona)",
+        "Bhagya Subrayan (U. Arizona)",
+        "Conor Ransome (U. Arizona)",
+        "Neev Shah (U. Arizona)",
+        "David Sand (U. Arizona)",
+        "Nathan Smith (U. Arizona)",
+        "Kate D. Alexander (U. Arizona)",
+        "on behalf of AZTEC",
+    ],
+    66: [     # SAGUARO
+        "Griffin Hosseinzadeh (UCSD)",
+        "Noah Franz (UofA)",
+        "David J. Sand (UofA)",
+        "Wen-fai Fong (NU)",
+        "Charles D. Kilpatrick (NU)",
+        "Bhagya Subrayan (UofA)",
+        "Conor Ransome (UofA)",
+        "Phillip Noel (UofA)",
+        "Manisha Shrestha (Monash)",
+        "Sergiy Vasylyev (UCSD)",
+        "Jennifer E. Andrews (NOIRLab)",
+        "on behalf of SAGUARO collaboration",
+    ],
+    176: [
+         "Griffin Hosseinzadeh (UCSD)",
+         "Nicholas Veira (NU)",
+         "Noah Franz (UofA)",
+         "Charles D. Kilpatrick (NU)",
+         "Bhagya Subrayan (UofA)",
+         "David J. Sand (UofA)",
+         "Wen-fai Fong (NU)",
+         "Phillip Noel (UofA)",
+         "Conor Ransome (UofA)",
+         "Manisha Shrestha (Monash)",
+         "Sergiy Vasylyev (UCSD)",
+         "Jennifer E. Andrews (NOIRLab)",
+         "on behalf of TROVE collaboration",],  # TROVE
+    177: [
+         "Griffin Hosseinzadeh (UCSD)",
+         "Brian Hsu (U. Arizona)",
+         "Sergiy Vasylyev (UCSD)",
+         "Aravind P. Ravi (UCDavis)",
+         "Jennifer E. Andrews (NOIRLab)",
+         "Bhagya Subrayan (UofA)",
+         "Conor Ransome (UofA)",
+         "Azalee Bostroem (UofA)",
+         "Manisha Shrestha (Monash)",
+         "Raphael Baer-Way (UV)",
+         "Jeniveve Pearson (UofA)",
+         "Jozsef Vinko (Szeged)",
+         "David J. Sand (UofA)", 
+         "Maryam Modjaz (UV)",
+         "Saurabh Jha (Rutgers)",
+         "on behalf of PASSTA collaboration"
+         ],  # PASSTA
+    178: [ 
+        "Conor Ransome (UofA)",
+        "Bhagya Subrayan (UofA)",
+        "David Sand (UofA)",
+        "Azalee Bostroem (UofA)",
+        "Jeniveve Pearson (UofA)",
+        "Brian Hsu (UofA)",
+        "Noah Franz (UofA)",
+        "Phillip Noel (UofA)",
+        "Griffin Hosseinzadeh (UCSD)",
+        "Jennifer Andrews (NOIRLab)",
+        "Manisha Shrestha (Monash)",
+        "Samuel Wyatt (Goddard)",
+        "Xander Hall (CMU)",
+        "Lei Hu (CMU)",
+        "Tomás Cabrera (CMU)",
+        "Antonella Palmese (CMU)",
+        "Frank Valdes (NOIRLab)",
+        "Kathy Vivas (NOIRLab)",
+        "Monika Soraisam (NOIRLab)",
+        "on behalf of Shadow collaboration",
+    ],#Shadow
+}
+def build_reporter(user_full_name, group_id=0):
+    """
+    Build the 'Reporter' field value. The logged-in user is listed first; if they also appear
+    in the chosen group's list, their full entry (with affiliation) is used instead of the bare
+    name, and they are not listed twice.
+    """
+    try:
+        members = list(TNS_REPORTER_GROUPS.get(int(group_id), []))
+    except (TypeError, ValueError):
+        members = []
+
+    user_entry = user_full_name or ''
+    if user_full_name:
+        for member in members:
+            # a list entry like "Jane Doe (University of Arizona)" starts with the person's full name
+            if member == user_full_name or member.startswith(user_full_name + ' ('):
+                user_entry = member
+                members.remove(member)
+                break
+
+    names = []
+    if user_entry:
+        names.append(user_entry)
+    names += members
+    return ', '.join(names)
+
+
+
+
 TNS_UNIT_CHOICES = [
     (0, "Other"),
     (1, "ABMag"),
@@ -424,7 +538,8 @@ class TargetClassifyForm(forms.Form):
     classification = forms.ChoiceField(choices=TNS_CLASSIFICATION_CHOICES, initial=(1, "SN"))
     redshift = forms.FloatField(required=False)
     group = forms.ChoiceField(choices=TNS_GROUP_CHOICES)
-    classification_remarks = forms.CharField(required=False, widget=forms.Textarea(attrs={'rows': 1}))
+    classification_remarks = forms.CharField(required=False, widget=forms.Textarea(attrs={'rows': 1}),
+initial="We report the classification of SN XXXX as a young SN XXX based on optical spectra obtained on XXXX using the XXXX spectrograph on the XXXX telescope from XXXX prgram (PID: XXXX). This target was classified using GELATO (Harutyunyan et al. 2008)/SNID-SAGE (Stoppa et al. 2026) and provided a best match to SN XXXX and SN XXXX at z=XXXX. We encourage follow-up spectroscopy.")
     observation_date = forms.DateTimeField()
     instrument = forms.ChoiceField(choices=TNS_INSTRUMENT_CHOICES)
     exposure_time = forms.FloatField(required=False)

--- a/custom_code/hooks.py
+++ b/custom_code/hooks.py
@@ -194,15 +194,43 @@ def vet_or_post_error(
             agn_df = agn_association_2d(target.id)
             ps_matches = point_source_association(target.id)
 
-	# geometric association with nearby Virgo (EVCC) galaxies
-        try:
-            evcc_matches = evcc_galaxy_check(target.id)
-        except Exception as e:
-            logger.error(f"EVCC check failed for {target.name}: {e}")
-            evcc_matches = []
-        if evcc_matches:
-            names = ", ".join(m["name"] for m in evcc_matches)
-            messages.append(f"Within Kron radius of EVCC galaxy: {names}")
+
+            # geometric association with nearby Virgo (EVCC) galaxies.
+            # read prior state BEFORE evcc_galaxy_check overwrites the TargetExtra,
+            # so we only Slack-alert on a newly discovered association, not re-vets.
+            prior = TargetExtra.objects.filter(
+                target_id=target.id, key="EVCC Within Galaxy"
+            ).first()
+            prior_had_match = prior is not None and prior.value not in (None, "None", "")
+
+            try:
+                evcc_matches = evcc_galaxy_check(target.id)
+            except Exception as e:
+                logger.error(f"EVCC check failed for {target.name}: {e}")
+                evcc_matches = []
+
+            if evcc_matches:
+                names = ", ".join(m["name"] for m in evcc_matches)
+                messages.append(f"Within Kron radius of EVCC galaxy: {names}")
+
+                if not prior_had_match:
+                    g = evcc_matches[0]  # closest
+                    target_url = settings.TARGET_LINKS[0][0].format(target=target)
+                    try:
+                        evcc_slack = SlackNotifier(
+                            slack_channel="nearby-galaxy-alerts",
+                            token=settings.SLACK_TOKEN_TNS50,
+                        )
+                        evcc_slack.send_slack_message_from_text(
+                            f":telescope: *{target.name}* is {g['offset_kron']}x Kron from Virgo "
+                            f"galaxy *{g['name']}* (offset {g['offset_arcsec']}\", r={g['rmag']}, "
+                            f"type {g['morphology']}, cz={g['cz_kms']} km/s). "
+                            f"Nearby-galaxy transient — please inspect here. "
+                            f"<{target_url}|SAGUARO>"
+                        )
+                    except Exception as e:
+                        logger.error(f"EVCC Slack alert failed for {target.name}: {e}")
+
 
         if "AsassnQ3C" in ps_matches:
             asassn = ps_matches["AsassnQ3C"][0]

--- a/custom_code/hooks.py
+++ b/custom_code/hooks.py
@@ -6,7 +6,9 @@ from candidate_vetting.vet import (
     host_association,
     point_source_association,
     agn_association_2d,
-)
+    evcc_galaxy_check,)
+
+
 from candidate_vetting.public_catalogs.phot_catalogs import TNS_Phot
 from trove_mpc import Transient
 
@@ -191,6 +193,16 @@ def vet_or_post_error(
             host_df = host_association(target.id)
             agn_df = agn_association_2d(target.id)
             ps_matches = point_source_association(target.id)
+
+	# geometric association with nearby Virgo (EVCC) galaxies
+        try:
+            evcc_matches = evcc_galaxy_check(target.id)
+        except Exception as e:
+            logger.error(f"EVCC check failed for {target.name}: {e}")
+            evcc_matches = []
+        if evcc_matches:
+            names = ", ".join(m["name"] for m in evcc_matches)
+            messages.append(f"Within Kron radius of EVCC galaxy: {names}")
 
         if "AsassnQ3C" in ps_matches:
             asassn = ps_matches["AsassnQ3C"][0]

--- a/custom_code/hooks.py
+++ b/custom_code/hooks.py
@@ -194,43 +194,39 @@ def vet_or_post_error(
             agn_df = agn_association_2d(target.id)
             ps_matches = point_source_association(target.id)
 
-
             # geometric association with nearby Virgo (EVCC) galaxies.
-            # read prior state BEFORE evcc_galaxy_check overwrites the TargetExtra,
-            # so we only Slack-alert on a newly discovered association, not re-vets.
             prior = TargetExtra.objects.filter(
                 target_id=target.id, key="EVCC Within Galaxy"
             ).first()
             prior_had_match = prior is not None and prior.value not in (None, "None", "")
 
             try:
-                evcc_matches = evcc_galaxy_check(target.id)
+                evcc_matches = json.loads(evcc_galaxy_check(target.id))
             except Exception as e:
                 logger.error(f"EVCC check failed for {target.name}: {e}")
                 evcc_matches = []
 
             if evcc_matches:
-                names = ", ".join(m["name"] for m in evcc_matches)
+                names = ", ".join(m["ID"] for m in evcc_matches)
                 messages.append(f"Within Kron radius of EVCC galaxy: {names}")
 
                 if not prior_had_match:
                     g = evcc_matches[0]  # closest
-                    target_url = settings.TARGET_LINKS[0][0].format(target=target)
                     try:
+                        target_url = settings.TARGET_LINKS[0][0].format(target=target)
                         evcc_slack = SlackNotifier(
                             slack_channel="nearby-galaxy-alerts",
                             token=settings.SLACK_TOKEN_TNS50,
                         )
                         evcc_slack.send_slack_message_from_text(
-                            f":telescope: *{target.name}* is {g['offset_kron']}x Kron from Virgo "
-                            f"galaxy *{g['name']}* (offset {g['offset_arcsec']}\", r={g['rmag']}, "
-                            f"type {g['morphology']}, cz={g['cz_kms']} km/s). "
-                            f"Nearby-galaxy transient — please inspect here. "
+                            f":telescope: *{target.name}* is {g['OffsetKron']}x Kron from Virgo "
+                            f"galaxy *{g['ID']}* (offset {g['Offset']}\", r={g['rMag']}, "
+                            f"type {g['Type']}, cz={g['cz']} km/s). "
+                            f"Nearby-galaxy transient — please inspect. "
                             f"<{target_url}|SAGUARO>"
                         )
                     except Exception as e:
                         logger.error(f"EVCC Slack alert failed for {target.name}: {e}")
-
 
         if "AsassnQ3C" in ps_matches:
             asassn = ps_matches["AsassnQ3C"][0]

--- a/custom_code/templatetags/target_list_extras.py
+++ b/custom_code/templatetags/target_list_extras.py
@@ -28,14 +28,43 @@ def islist(value):
 @register.inclusion_tag('tom_targets/partials/galaxy_table.html')
 def galaxy_table(target):
     """
-    Displays the most likely host galaxy matches.
+    Displays the most likely host galaxy matches, with a radio button to pick a preferred host.
     """
     te = TargetExtra.objects.filter(target=target, key='Host Galaxies')
     if te.exists():
         galaxies = json.loads(te.first().value)
     else:
         galaxies = None
-    return {'galaxies': galaxies}
+
+    # which galaxy did the user already pick? (matched by ID + Source so it survives re-vetting)
+    preferred = TargetExtra.objects.filter(target=target, key='Preferred Host Galaxy').first()
+    preferred_key = None
+    if preferred is not None:
+        pref = json.loads(preferred.value)
+        preferred_key = (pref.get('ID'), pref.get('Source'))
+
+    if galaxies:
+        for galaxy in galaxies:
+            galaxy['is_preferred'] = (galaxy.get('ID'), galaxy.get('Source')) == preferred_key
+    any_preferred = bool(galaxies) and any(g.get('is_preferred') for g in galaxies)
+    return {'galaxies': galaxies, 'target': target, 'any_preferred': any_preferred}
+    #return {'galaxies': galaxies, 'target': target}
+
+
+
+
+
+#@register.inclusion_tag('tom_targets/partials/galaxy_table.html')
+#def galaxy_table(target):
+ #   """
+  #  Displays the most likely host galaxy matches.
+   # """
+    #te = TargetExtra.objects.filter(target=target, key='Host Galaxies')
+    #if te.exists():
+     #   galaxies = json.loads(te.first().value)
+    #else:
+     #   galaxies = None
+    #return {'galaxies': galaxies}
 
 
 FIELDS = SurveyField.objects.order_by('name')

--- a/custom_code/urls.py
+++ b/custom_code/urls.py
@@ -6,6 +6,9 @@ from .views import ObservationCreateView, TargetNameSearchView, TargetListView
 from .views import CSSFieldListView, GWListView, GRBListView, NeutrinoListView, UnknownListView
 from .views import CSSFieldExportView, CSSFieldSubmitView, EventCandidateCreateView
 from tom_nonlocalizedevents.views import SupereventIdView
+from .views import SelectHostGalaxyView, ClearHostGalaxyView
+
+
 
 # NEW: Import DECam thumbnail view
 from .decam_views import DecamCandidateView, DecamCandidateListView
@@ -22,6 +25,8 @@ urlpatterns = [
     path('candidates/', CandidateListView.as_view(), name='candidates'),
     path('targets/<int:pk>/report/', TargetReportView.as_view(), name='report'),
     path('targets/<int:pk>/classify/', TargetClassifyView.as_view(), name='classify'),
+    path('targets/<int:pk>/select-host/<int:index>/', SelectHostGalaxyView.as_view(), name='select-host'),
+    path('targets/<int:pk>/clear-host/', ClearHostGalaxyView.as_view(), name='clear-host'),
     path('targets/<int:pk>/vet/', TargetVettingView.as_view(), name='vet'),
     path('targets/<int:pk>/mpc/', TargetMPCView.as_view(), name='mpc'),
     path('targets/search/', TargetNameSearchView.as_view(), name='search'),

--- a/custom_code/views.py
+++ b/custom_code/views.py
@@ -26,6 +26,8 @@ from .forms import TargetListExtraFormset, TargetReportForm, TargetClassifyForm
 from .forms import NonLocalizedEventFormHelper, CandidateFormHelper
 from .forms import TNS_FILTER_CHOICES, TNS_INSTRUMENT_CHOICES, TNS_CLASSIFICATION_CHOICES
 from .forms import TNS_GROUP_CHOICES, TNS_DATA_SOURCE_GROUP_CHOICES
+from .forms import TNS_REPORTER_GROUPS, build_reporter
+
 from .hooks import vet_or_post_error, update_or_create_target_extra, target_run_mpc
 from .templatetags.skymap_extras import get_preferred_localization
 from .templatetags.target_extras import split_name
@@ -260,9 +262,16 @@ class TargetReportView(PermissionListMixin, TemplateResponseMixin, FormMixin, Pr
     form_class = TargetReportForm
     template_name = 'tom_targets/targetreport_form.html'
 
+    #def get_context_data(self, **kwargs):
+     #   context = super().get_context_data(**kwargs)
+      #  context['target'] = Target.objects.get(pk=self.kwargs['pk'])
+       # return context
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['target'] = Target.objects.get(pk=self.kwargs['pk'])
+        # data for the JS that refills the Reporter field when the reporting group changes
+        context['reporter_groups'] = TNS_REPORTER_GROUPS
+        context['user_full_name'] = self.request.user.get_full_name()
         return context
 
     def get_initial(self):
@@ -270,7 +279,8 @@ class TargetReportView(PermissionListMixin, TemplateResponseMixin, FormMixin, Pr
         initial = {
             'ra': target.ra,
             'dec': target.dec,
-            'reporter': f'{self.request.user.get_full_name()}',
+            #'reporter': f'{self.request.user.get_full_name()}',
+            'reporter': build_reporter(self.request.user.get_full_name()),
         }
         alias = target.aliases.first()
         if alias:
@@ -297,6 +307,15 @@ class TargetReportView(PermissionListMixin, TemplateResponseMixin, FormMixin, Pr
                 initial['nondetection_instrument'] = TNS_INSTRUMENT_IDS.get(instrument_name)
             else:
                 initial['archive'] = 0
+        # pre-fill Host name + Host redshift from the galaxy the user picked on the Host Galaxies tab
+        preferred = target.targetextra_set.filter(key='Preferred Host Galaxy').first()
+        if preferred is not None:
+            galaxy = json.loads(preferred.value)
+            if galaxy.get('ID'):
+                initial['host_name'] = galaxy['ID']
+            z = galaxy.get('z')
+            if isinstance(z, (int, float)) and 0. < z < 20.:  # skip the -999 "no redshift" values
+                initial['host_redshift'] = z
         return initial
 
     def form_valid(self, form):
@@ -322,6 +341,43 @@ class TargetReportView(PermissionListMixin, TemplateResponseMixin, FormMixin, Pr
         return reverse_lazy('targets:detail', kwargs=self.kwargs)
 
 
+
+class SelectHostGalaxyView(LoginRequiredMixin, RedirectView):
+    """
+    Records which host galaxy the user picked on the Host Galaxies tab.
+    Stores it as a 'Preferred Host Galaxy' TargetExtra so the report form can use it later.
+    """
+    def get(self, request, *args, **kwargs):
+        target = Target.objects.get(pk=kwargs['pk'])
+        index = kwargs['index']
+
+        te = target.targetextra_set.filter(key='Host Galaxies').first()
+        galaxies = json.loads(te.value) if te is not None else None
+
+        if not galaxies or index < 0 or index >= len(galaxies):
+            messages.error(request, 'Could not find the selected host galaxy.')
+        else:
+            galaxy = galaxies[index]
+            update_or_create_target_extra(target, 'Preferred Host Galaxy', json.dumps(galaxy))
+            messages.success(request, f"Selected {galaxy.get('ID')} as the preferred host galaxy.")
+
+        referer = request.META.get('HTTP_REFERER')
+        if referer:
+            return HttpResponseRedirect(referer)
+        return HttpResponseRedirect(reverse_lazy('targets:detail', kwargs={'pk': kwargs['pk']}) + '?tab=host-galaxy')
+
+
+class ClearHostGalaxyView(LoginRequiredMixin, RedirectView):
+    """Removes the user's preferred host galaxy so the report form host fields stay blank."""
+    def get(self, request, *args, **kwargs):
+        target = Target.objects.get(pk=kwargs['pk'])
+        target.targetextra_set.filter(key='Preferred Host Galaxy').delete()
+        messages.success(request, 'Cleared the preferred host galaxy.')
+        referer = request.META.get('HTTP_REFERER')
+        if referer:
+            return HttpResponseRedirect(referer)
+        return HttpResponseRedirect(reverse_lazy('targets:detail', kwargs={'pk': kwargs['pk']}) + '?tab=host-galaxy')
+
 class TargetClassifyView(PermissionListMixin, TemplateResponseMixin, FormMixin, ProcessFormView):
     """
     View that handles classifying a target on the TNS.
@@ -329,9 +385,17 @@ class TargetClassifyView(PermissionListMixin, TemplateResponseMixin, FormMixin, 
     form_class = TargetClassifyForm
     template_name = 'tom_targets/targetclassify_form.html'
 
+    #def get_context_data(self, **kwargs):
+     #   context = super().get_context_data(**kwargs)
+      #  context['target'] = Target.objects.get(pk=self.kwargs['pk'])
+       # return context
+    
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['target'] = Target.objects.get(pk=self.kwargs['pk'])
+        # data for the JS that refills the Reporter field when the reporting group changes
+        context['reporter_groups'] = TNS_REPORTER_GROUPS
+        context['user_full_name'] = self.request.user.get_full_name()
         return context
 
     def get_form_kwargs(self):
@@ -343,7 +407,8 @@ class TargetClassifyView(PermissionListMixin, TemplateResponseMixin, FormMixin, 
         target = Target.objects.get(pk=self.kwargs['pk'])
         initial = {
             'name': split_name(target.name)['basename'],
-            'classifier': f'{self.request.user.get_full_name()}',
+        # 'classifier': f'{self.request.user.get_full_name()}',
+          'classifier': build_reporter(self.request.user.get_full_name()),
         }
         classifications = target.targetextra_set.filter(key='Classification')
         if classifications.exists():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 astroplan
 astropy
 astroquery
-candidate_vetting @ git+https://github.com/astro-trove/candidate_vetting.git
+candidate_vetting @ git+https://github.com/astro-trove/candidate_vetting.git@v0.2.0-alpha
 django
 django-crispy-forms
 django-extensions

--- a/templates/tom_targets/partials/galaxy_table.html
+++ b/templates/tom_targets/partials/galaxy_table.html
@@ -1,5 +1,22 @@
 {% load tom_common_extras target_list_extras %}
 
+
+<a href="{% url 'custom_code:clear-host' pk=target.id %}" id="clear-preferred-host"
+   class="btn btn-sm btn-outline-secondary mb-2"
+   title="Remove the preferred host so the report form host fields stay blank">Clear preferred host</a>
+<script>
+  document.getElementById('clear-preferred-host').addEventListener('click', function (e) {
+    e.preventDefault();
+    var btn = this;
+    fetch(btn.getAttribute('href')).then(function () {
+      btn.style.display = 'none';
+      document.querySelectorAll('input[name="preferred_host"]').forEach(function (r) { r.checked = false; });
+      document.querySelectorAll('tr.table-primary').forEach(function (tr) { tr.classList.remove('table-primary'); });
+    });
+  });
+</script>
+
+
 <table class="galaxies table table-hover">
     <tr>
       <th scope="col">ID</th>
@@ -10,6 +27,7 @@
       <th scope="col">Redshift</th>
       <th scope="col">Mag.  <br/> (AB)</th>
       <th scope="col">Source</th>
+      <th scope="col">User Preferred Host</th>
     </tr>
   {% for galaxy in galaxies %}
     <tr>
@@ -47,6 +65,11 @@
       {% endif %}
       <td><i>{{ galaxy.Filter }}</i>&nbsp;=&nbsp;{{ galaxy.Mags|floatformat:1 }}</td>
       <td>{{ galaxy.Source }}</td>
+      <td>
+        <input type="radio" name="preferred_host"
+               {% if galaxy.is_preferred %}checked{% endif %}
+               onclick="window.location.href='{% url 'custom_code:select-host' pk=target.id index=forloop.counter0 %}';">
+      </td>
     </tr>
   {% empty %}
     <tr><td colspan=9>No host galaxies stored</td></tr>

--- a/templates/tom_targets/partials/target_data.html
+++ b/templates/tom_targets/partials/target_data.html
@@ -54,7 +54,7 @@
 <h4>Point Source Matches</h4>
 <dl class="row">
 {% for target_extra in target.targetextra_set.all %}
-{% if target_extra.key not in extras and target_extra.key|slice:':4' != 'Host' and target_extra.key != 'healpix' %}
+{% if target_extra.key not in extras and target_extra.key|slice:':4' != 'Host' and target_extra.key != 'healpix' and target_extra.key != 'Preferred Host Galaxy' %}
 <dt class="col-sm-6">{{ target_extra.key }}</dt>
     {% if target_extra.key|slice:'-6:' == 'Offset' %}
         <dd class="col-sm-6">{{ target_extra.float_value|floatformat:1 }}"</dd>

--- a/templates/tom_targets/targetclassify_form.html
+++ b/templates/tom_targets/targetclassify_form.html
@@ -11,4 +11,55 @@
         </form>
     </div>
 </div>
+{{ reporter_groups|json_script:"reporter-groups-data" }}
+{{ user_full_name|json_script:"reporter-user-name" }}
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    var groups = JSON.parse(document.getElementById('reporter-groups-data').textContent);
+    var userName = JSON.parse(document.getElementById('reporter-user-name').textContent);
+    var groupField = document.getElementById('id_group');
+    var reporterField = document.getElementById('id_classifier');
+    if (!groupField || !reporterField) { return; }
+    groupField.addEventListener('change', function () {
+      var members = (groups[this.value] || []).slice();
+      var userEntry = userName || '';
+      if (userName) {
+        for (var i = 0; i < members.length; i++) {
+          var m = members[i];
+          if (m === userName || m.indexOf(userName + ' (') === 0) {
+            userEntry = m;
+            members.splice(i, 1);
+            break;
+          }
+        }
+      }
+      var names = [];
+      if (userEntry) { names.push(userEntry); }
+      names = names.concat(members);
+      reporterField.value = names.join(', ');
+    });
+  });
+</script>
+<style>
+  label[for="id_classifier"]     { color: red; font-weight: bold; }
+  label[for="id_group"]          { color: red; font-weight: bold; }
+label[for="id_name"]          { color: red; font-weight: bold; }  
+label[for="id_group"]          { color: red; font-weight: bold; }
+label[for="id_classification"] { color: red; font-weight: bold; }
+label[for="id_redshift"]       { color: red; font-weight: bold; }
+label[for="id_classification_remarks"]          { color: red; font-weight: bold; }
+label[for="id_observation_date"]          { color: red; font-weight: bold; }
+label[for="id_observer"]          { color: red; font-weight: bold; }
+label[for="id_reducer"]          { color: red; font-weight: bold; }
+label[for="id_instrument"]          { color: red; font-weight: bold; }
+label[for="id_exposure_time"]          { color: red; font-weight: bold; }
+label[for="id_spectrum_type"]          { color: red; font-weight: bold; }
+label[for="id_ascii_file"]          { color: red; font-weight: bold; }
+label[for="id_fits_file"]          { color: red; font-weight: bold; }
+label[for="id_spectrum_remarks"]          { color: red; font-weight: bold; }
+</style>
+
+
+
+
 {% endblock %}

--- a/templates/tom_targets/targetreport_form.html
+++ b/templates/tom_targets/targetreport_form.html
@@ -11,4 +11,65 @@
         </form>
     </div>
 </div>
+{{ reporter_groups|json_script:"reporter-groups-data" }}
+{{ user_full_name|json_script:"reporter-user-name" }}
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    var groups = JSON.parse(document.getElementById('reporter-groups-data').textContent);
+    var userName = JSON.parse(document.getElementById('reporter-user-name').textContent);
+    var groupField = document.getElementById('id_reporting_group');
+    var reporterField = document.getElementById('id_reporter');
+    if (!groupField || !reporterField) { return; }
+    groupField.addEventListener('change', function () {
+      var members = (groups[this.value] || []).slice();
+      var userEntry = userName || '';
+      if (userName) {
+        for (var i = 0; i < members.length; i++) {
+          var m = members[i];
+          if (m === userName || m.indexOf(userName + ' (') === 0) {
+            userEntry = m;
+            members.splice(i, 1);
+            break;
+          }
+        }
+      }
+      var names = [];
+      if (userEntry) { names.push(userEntry); }
+      names = names.concat(members);
+      reporterField.value = names.join(', ');
+    });
+  });
+</script>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    var reportingGroup = document.getElementById('id_reporting_group');
+    var dataSourceGroup = document.getElementById('id_data_source_group');
+    if (!reportingGroup || !dataSourceGroup) { return; }
+    reportingGroup.addEventListener('change', function () {
+      var val = this.value;
+      if (val === '0') { return; }   // "None" picked -> leave data source alone
+      var exists = Array.from(dataSourceGroup.options).some(function (o) { return o.value === val; });
+      if (exists) { dataSourceGroup.value = val; }   // match it (you can still change it manually)
+    });
+  });
+</script>
+
+
+<style>
+  label[for="id_reporter"]        { color: red; font-weight: bold; }
+  label[for="id_reporting_group"] { color: red; font-weight: bold; }
+  label[for="id_ra"]         { color: red; font-weight: bold; }
+  label[for="id_dec"]       { color: red; font-weight: bold; }
+  label[for="id_discovery_date"]   { color: red; font-weight: bold; }
+label[for="id_at_type"]   { color: red; font-weight: bold; }
+label[for="id_observation_date"]   { color: red; font-weight: bold; }
+label[for="id_instrument"]   { color: red; font-weight: bold; }
+label[for="id_flux"]   { color: red; font-weight: bold; }
+label[for="id_flux_error"]   { color: red; font-weight: bold; }
+label[for="id_flux_units"]   { color: red; font-weight: bold; }
+label[for="id_filter"]   { color: red; font-weight: bold; }
+label[for="id_data_source_group"]   { color: red; font-weight: bold; }
+</style>
+
 {% endblock %}


### PR DESCRIPTION
Depends on: astro-trove/candidate_vetting#12 (merge & deploy first)

- Wire evcc_galaxy_check (from #12) into vet_or_post_error: every created target is cross-matched against the EVCC, only if the target matches the footprint (this is implemented in the vetting code on trove -evcc_galaxy_check).

- Save matches to "EVCC Within Galaxy" TargetExtra; fire a Slack alert to #nearby-galaxy-alerts on a new association (galaxy name, offset, offset-in-Kron, r-mag, morphology, cz + target link).

- Slack fires only on first discovery — prior TargetExtra read before overwrite — to avoid re-vet spam.

- Both EVCC call and Slack send wrapped in try/except so neither can break the rest of vetting.

- Covers DECam + LSST/ANTARES with no changes to decam_ingestion or alertstream_handlers (both already hit vet_or_post_error(created=True)).

- Changes only in custom_code/hooks.py. Uses existing SLACK_TOKEN_TNS50 and settings.TARGET_LINKS[0][0].

Deploy order: #12 first (provides the function), then this. Requires #nearby-galaxy-alerts with the TNS50 bot invited (this is tested now, check #nearby-galaxy-alerts channel on LSST slack) 

Tested (dev): AT2017des → EVCC 1554 (0.20 Kron radii), alert posted with link; off-Virgo target → no key, no error; alert fires once on discovery, silent on re-vet; runs even with run_mpc=False, run_atlas=False.